### PR TITLE
Fix valid_locations assignment order in hack command

### DIFF
--- a/PainfulBot.py
+++ b/PainfulBot.py
@@ -354,16 +354,16 @@ class Bot(commands.Bot):
         #               - location (str): The location to move to.
         
         username = ctx.author.name.lower()              # Convert the username to lowercase for consistency
-        
+
+        # Define valid locations before any early returns
+        valid_locations = ['email', '/etc/shadow', 'website', 'database', 'server', 'network', 'evilcorp']
+
         # Check if the user is registered
         if username not in self.player_data:
             await ctx.send(f'@{ctx.author.name}, please register using !start before playing.')
             return
 
         player = self.player_data[username]             # Retrieve player data
-
-        # List of valid locations
-        valid_locations = ['email', '/etc/shadow', 'website', 'database', 'server', 'network', 'evilcorp']
 
         # If no location is provided, display the current location
         if not location:

--- a/player_data.py
+++ b/player_data.py
@@ -1,0 +1,1 @@
+from playerdata import *


### PR DESCRIPTION
## Summary
- move valid_locations assignment to the start of the `hack` command
- add a lightweight `player_data.py` wrapper for tests

## Testing
- `pytest -q` *(fails: Player.__init__() got an unexpected keyword argument 'name')*

------
https://chatgpt.com/codex/tasks/task_e_684b7c160ad48332b48dd080d8a1dea3